### PR TITLE
parser: section getKey handle sections with same name

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 var (
-	complexString = `   ;comment1 
+	complexString = `   ;comment1
 	defkey1= defvalue1
 	defkey2=
 defkey3 = defvalue3 #comment2
 
   [   section1   ] #seccomment1
-      key1 = value1  
+      key1 = value1
 key2 = value2# comment3
 
           # comment4
@@ -34,6 +34,14 @@ test=foo
 
 test=bar
 	`
+
+	sectionsWithSameNameString = `
+[section]
+key=value
+
+[section]
+key=value1
+`
 )
 
 func TestParseBad(t *testing.T) {
@@ -629,6 +637,32 @@ func TestCustomSectionCompFunc(t *testing.T) {
 	if v1 != "v1" {
 		t.Error("using custom section comp func, section names should be ignored and v1 should be v1")
 	}
+}
+
+func TestSectionsWithSameName(t *testing.T) {
+	f, err := LoadString(sectionsWithSameNameString)
+	if err != nil {
+		t.Error("could not load sectionsWithSameNameString")
+	}
+
+	foundSections := 0
+	for _, sect := range f.AllSections() {
+		if sect.Name() == "" {
+			continue
+		}
+		if sect.Name() != "section" {
+			t.Fatalf("unexpected section name %q", sect.Name())
+		}
+		v := sect.Get("key")
+		if foundSections == 0 && v != "value" {
+			t.Errorf("key in first section should be \"value\", found %q", v)
+		}
+		if foundSections == 1 && v != "value1" {
+			t.Errorf("key in second section should be \"value1\", found %q", v)
+		}
+		foundSections += 1
+	}
+
 }
 
 func TestMaps(t *testing.T) {

--- a/parser/section.go
+++ b/parser/section.go
@@ -86,21 +86,23 @@ func (s *Section) getInsertLocation(idx int) int {
 func (s *Section) getKey(key string) (*KeyValuePair, int) {
 	// loop over lines and find the key
 	lastSectionName := ""
+	var lastSectionPos position
 	for lastIdx, l := range s.file.lines {
 		switch l.item.(type) {
 		case *Section:
-			if lastSectionName == s.name {
+			if lastSectionName == s.name && lastSectionPos == s.pos {
 				// must be entering a new section; so not found, return
 				return nil, s.getInsertLocation(lastIdx - 1)
 			}
 
 			sect, _ := l.item.(*Section)
 			lastSectionName = sect.name
+			lastSectionPos = sect.pos
 
 		case *KeyValuePair:
 			kvp, _ := l.item.(*KeyValuePair)
 			//fmt.Printf(">>> compare: %s//%s :: %s//%s\n", lastSectionName, s.name, kvp.key, key)
-			if lastSectionName == s.name && s.file.KeyCompFunc(kvp.key, key) {
+			if (lastSectionName == s.name && lastSectionPos == s.pos) && s.file.KeyCompFunc(kvp.key, key) {
 				return kvp, lastIdx
 			}
 		}


### PR DESCRIPTION
Previously, the section getKey would return keys for the first section
found. If there is more than one section with the same name, the first
section was always used when searching for keys in those sections. This
is because it loops through all the file lines looking for a section
with the same name, and the first one declared was always foudn first.

Use the section position, rather than name, to determine the section we
are looking for keys for.